### PR TITLE
freetype 2.11.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,8 +7,6 @@ package:
 source:
   url: http://download.savannah.gnu.org/releases/freetype/freetype-{{ version }}.tar.gz
   sha256: a45c6b403413abd5706f3582f04c8339d26397c4304b78fa552f2215df64101f
-  #patches:
-  #  - 0003-Install-the-pkg-config-file-on-Windows-too.patch
 
 build:
   number: 0
@@ -24,8 +22,6 @@ requirements:
     - make  # [not win]
     - ninja  # [win]
     - pkg-config  # [linux and aarch64]
-    - patch  # [not win]
-    - m2-patch  # [win]
   host:
     - libpng
     - zlib


### PR DESCRIPTION
Update freetype to 2.11.0

Category:  anaconda | subcategory:  dependency | pkg_type:  library
Popularity:  17330594 downloads -  freetype  2.10.4  A Free, High-Quality, and Portable Font Engine
Version change: bump version number from 2.10.4 to 2.11.0
  license: GPL-2.0-only and LicenseRef-FreeType
dev_url: http://git.savannah.gnu.org/cgit/freetype/
Changelog: http://git.savannah.gnu.org/cgit/freetype/freetype2.git/tree/docs/CHANGES
License: https://gitlab.freedesktop.org/freetype/freetype/-/blob/master/LICENSE.TXT

The package freetype is mentioned inside the packages:
alacritty | cairo | ffmpeg | fontconfig | freetype-py | graphviz | gtk3 | harfbuzz | libgd | libgd-2.2.5 | librsvg | matplotlib | opencv | pango | pillow | poppler | qt | qt-5.11 | qt-5.12 | qt-5.6 | reportlab | texlive-core | vispy | vtk |

Actions:
1. Add missing (m2-)patch build requirement
2. Update dev_url
3. Disable a patch

Result:
- all-succeeded
