### PR TITLE
Update Freetype to Version 2.11.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ source:
   url: http://download.savannah.gnu.org/releases/freetype/freetype-{{ version }}.tar.gz
   sha256: a45c6b403413abd5706f3582f04c8339d26397c4304b78fa552f2215df64101f
   #patches:
+    # 2021/7/20: the pkg-config file was fixed,
+    # see https://gitlab.freedesktop.org/freetype/freetype/-/commit/66005cbae1ff19ab15c7ade1a3bd22665be2a9fc
     #- 0003-Install-the-pkg-config-file-on-Windows-too.patch
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,8 +7,8 @@ package:
 source:
   url: http://download.savannah.gnu.org/releases/freetype/freetype-{{ version }}.tar.gz
   sha256: a45c6b403413abd5706f3582f04c8339d26397c4304b78fa552f2215df64101f
-  patches:
-    - 0003-Install-the-pkg-config-file-on-Windows-too.patch
+  #patches:
+    #- 0003-Install-the-pkg-config-file-on-Windows-too.patch
 
 build:
   number: 0
@@ -24,6 +24,8 @@ requirements:
     - make  # [not win]
     - ninja  # [win]
     - pkg-config  # [linux and aarch64]
+    - patch  # [not win]
+    - m2-patch  # [win]
   host:
     - libpng
     - zlib
@@ -39,6 +41,7 @@ test:
 about:
   home: https://www.freetype.org/
   license: GPL-2.0-only and LicenseRef-FreeType
+  License_family: GPL AND Other
   license_file:
     - docs/GPLv2.TXT
     - docs/FTL.TXT
@@ -47,9 +50,9 @@ about:
     FreeType is designed to be small, efficient, highly customizable
     and portable while capable of producing high-quality output (glyph images)
     of most vector and bitmap font formats.
-  doc_url: http://freetype.sourceforge.net/freetype2/documentation.html
+  doc_url: https://www.freetype.org/freetype2/docs/documentation.html
   doc_source_url: https://sourceforge.net/projects/freetype/?source=navbar
-  dev_url: http://git.savannah.gnu.org/cgit/freetype/
+  dev_url: https://gitlab.freedesktop.org/freetype/freetype
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.10.4" %}
+{% set version = "2.11.0" %}
 
 package:
   name: freetype
@@ -6,7 +6,7 @@ package:
 
 source:
   url: http://download.savannah.gnu.org/releases/freetype/freetype-{{ version }}.tar.gz
-  sha256: 5eab795ebb23ac77001cfb68b7d4d50b5d6c7469247b0b01b2c953269f658dac
+  sha256: a45c6b403413abd5706f3582f04c8339d26397c4304b78fa552f2215df64101f
   patches:
     - 0003-Install-the-pkg-config-file-on-Windows-too.patch
 


### PR DESCRIPTION

1. check the upstream
https://gitlab.freedesktop.org/freetype/freetype
2. check the pinnings
https://gitlab.freedesktop.org/freetype/freetype/-/blob/master/meson.build
https://gitlab.freedesktop.org/freetype/freetype/-/blob/master/configure
3. check changelogs
https://gitlab.freedesktop.org/freetype/freetype/-/blob/master/docs/CHANGES

The changes mentioned are correction but no breanking changes are mentioned

4. additional research
https://github.com/conda-forge/freetype-feedstock/issues/42

There is a known issue with Matplotlib crassing. 
Maybe we should investigate this issue further

5. verify dev_url
   https://gitlab.freedesktop.org/freetype/freetype
6. verify doc_url
    https://www.freetype.org/freetype2/docs/documentation.html
7. pip is not used in this package
8. verify the test section
9. additional tests

In order to test the `freetype` package version `2.11.0` the following command was used:
`conda build freetype-feedstock --test` 
The test result was the following:
`All tests passed`
