### PR TITLE
freetype 2.13.3

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,7 +8,5 @@
             --enable-freetype-config
 
 make -j${CPU_COUNT} ${VERBOSE_AT}
-if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" ]]; then
 make check
-fi
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,5 +8,7 @@
             --enable-freetype-config
 
 make -j${CPU_COUNT} ${VERBOSE_AT}
+if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" ]]; then
 make check
+fi
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
 
 about:
   home: https://freetype.org/
-  license: GPL-2.0-only
+  license: GPL-2.0-only or FTL
   license_family: Other
   license_file:
     - docs/GPLv2.TXT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,9 @@ about:
   home: https://freetype.org/
   license: GPL-2.0-only
   license_family: Other
-  license_file: LICENSE
+  license_file:
+    - docs/GPLv2.TXT
+    - docs/FTL.TXT
   license_url: https://gitlab.freedesktop.org/freetype/freetype/-/blob/master/LICENSE.TXT
   summary: A Free, High-Quality, and Portable Font Engine
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://download.savannah.gnu.org/releases/freetype/freetype-{{ version }}.tar.gz
+  url: https://download-mirror.savannah.gnu.org/releases/freetype/freetype-{{ version }}.tar.gz
   sha256: 5c3a8e78f7b24c20b25b54ee575d6daa40007a5f4eea2845861c3409b3021747
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,14 +42,12 @@ about:
   license_file:
     - docs/GPLv2.TXT
     - docs/FTL.TXT
-  license_url: https://gitlab.freedesktop.org/freetype/freetype/-/blob/master/LICENSE.TXT
   summary: A Free, High-Quality, and Portable Font Engine
   description: |
     FreeType is designed to be small, efficient, highly customizable
     and portable while capable of producing high-quality output (glyph images)
     of most vector and bitmap font formats.
   doc_url: https://gitlab.freedesktop.org/freetype/freetype/-/blob/master/README
-  doc_source_url: https://gitlab.freedesktop.org/freetype/freetype
   dev_url: https://gitlab.freedesktop.org/freetype/freetype
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.12.1" %}
+{% set version = "2.13.3" %}
 
 package:
   name: freetype
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://download.savannah.gnu.org/releases/freetype/freetype-{{ version }}.tar.gz
-  sha256: efe71fd4b8246f1b0b1b9bfca13cfff1c9ad85930340c27df469733bbb620938
+  sha256: 5c3a8e78f7b24c20b25b54ee575d6daa40007a5f4eea2845861c3409b3021747
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,8 @@ requirements:
     - cmake  # [win]
     - make  # [not win]
     - ninja  # [win]
-    - pkg-config  # [linux and aarch64]
+    - pkg-config           # [unix]
+    - libtool              # [unix]
   host:
     - libpng
     - zlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,11 +37,9 @@ test:
 
 about:
   home: https://freetype.org/
-  license: GPL-2-only and LicenseRef-FreeType
+  license: GPL-2.0-only
   license_family: Other
-  license_file:
-    - docs/GPLv2.TXT
-    - docs/FTL.TXT
+  license_file: LICENSE
   license_url: https://gitlab.freedesktop.org/freetype/freetype/-/blob/master/LICENSE.TXT
   summary: A Free, High-Quality, and Portable Font Engine
   description: |


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-7390](https://anaconda.atlassian.net/browse/PKG-7390)
- [Upstream repository](https://gitlab.freedesktop.org/freetype/freetype/-/tree/VER-2-13-3?ref_type=tags)
- [Upstream changelog/diff](https://gitlab.freedesktop.org/freetype/freetype/-/compare/VER-2-13-2...VER-2-13-3?from_project_id=7950)


### Explanation of changes:

- Set new version
- Update dependencies
- Fix license issues
- New source URL to avoid hash inconsistencies on different platforms
- Linter fixes


[PKG-7390]: https://anaconda.atlassian.net/browse/PKG-7390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ